### PR TITLE
Fix Soundcloud broken tests

### DIFF
--- a/tests/test_soundcloud.py
+++ b/tests/test_soundcloud.py
@@ -6,11 +6,24 @@ from __future__ import unicode_literals
 # stdlib imports
 import os
 import unittest
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 
 # local imports
 from radiobabel import SoundcloudClient
 from radiobabel.errors import TrackNotFound
 from radiobabel.test_utils import load_config
+
+
+def remove_query_from_images(track):
+    keys = ['image_small', 'image_medium', 'image_large']
+
+    for image in keys:
+        parsed = urlparse(track[image])
+        parsed = parsed._replace(query='')
+        track[image] = parsed.geturl()
 
 
 class ClientInitializationTests(unittest.TestCase):
@@ -40,6 +53,7 @@ class LookupTests(unittest.TestCase):
         """Soundcloud: Looking up a valid track (str) returns the expected data
         """
         track = self.client.lookup_track('18048610')
+        remove_query_from_images(track)
         self.assertDictEqual(track, {
             "source_type": "soundcloud",
             "source_id": 18048610,
@@ -56,15 +70,16 @@ class LookupTests(unittest.TestCase):
             "preview_url": "https://api.soundcloud.com/tracks/18048610/stream",
             "uri": "soundcloud:song/Sleep Rules Everything Around Me.18048610",
             "track_number": 0,
-            "image_small": "https://i1.sndcdn.com/artworks-000008722839-oyzy1n-t67x67.jpg?debc7fd",
-            "image_medium": "https://i1.sndcdn.com/artworks-000008722839-oyzy1n-t300x300.jpg?debc7fd",
-            "image_large": "https://i1.sndcdn.com/artworks-000008722839-oyzy1n-t500x500.jpg?debc7fd",
+            "image_small": "https://i1.sndcdn.com/artworks-000008722839-oyzy1n-t67x67.jpg",
+            "image_medium": "https://i1.sndcdn.com/artworks-000008722839-oyzy1n-t300x300.jpg",
+            "image_large": "https://i1.sndcdn.com/artworks-000008722839-oyzy1n-t500x500.jpg",
         })
 
     def test_valid_lookup_int(self):
         """Soundcloud: Looking up a valid track (str) returns the expected data
         """
         track = self.client.lookup_track(18048610)
+        remove_query_from_images(track)
         self.assertDictEqual(track, {
             "source_type": "soundcloud",
             "source_id": 18048610,
@@ -81,9 +96,9 @@ class LookupTests(unittest.TestCase):
             "preview_url": "https://api.soundcloud.com/tracks/18048610/stream",
             "uri": "soundcloud:song/Sleep Rules Everything Around Me.18048610",
             "track_number": 0,
-            "image_small": "https://i1.sndcdn.com/artworks-000008722839-oyzy1n-t67x67.jpg?debc7fd",
-            "image_medium": "https://i1.sndcdn.com/artworks-000008722839-oyzy1n-t300x300.jpg?debc7fd",
-            "image_large": "https://i1.sndcdn.com/artworks-000008722839-oyzy1n-t500x500.jpg?debc7fd",
+            "image_small": "https://i1.sndcdn.com/artworks-000008722839-oyzy1n-t67x67.jpg",
+            "image_medium": "https://i1.sndcdn.com/artworks-000008722839-oyzy1n-t300x300.jpg",
+            "image_large": "https://i1.sndcdn.com/artworks-000008722839-oyzy1n-t500x500.jpg",
         })
 
     def test_invalid_lookup(self):


### PR DESCRIPTION
Sound cloud adds a query suffix at the end of the images URL that can
change, causing the test to fail.
